### PR TITLE
prevent return nil to neotest

### DIFF
--- a/lua/neotest-dart/parser.lua
+++ b/lua/neotest-dart/parser.lua
@@ -26,6 +26,9 @@ local function construct_neotest_status(test_result)
   if test_result.skipped then
     return 'skipped'
   end
+  if test_result.status == nil then
+    return 'running'
+  end
   return test_result.status
 end
 


### PR DESCRIPTION
hi guys, 
Flutter won't return status when an application print log.
Example: 
{
  message = "message",
  time = 56209
}

Problem: status = nil will make neotest summary crash
Solution: return 'running' instead