### PR TITLE
Add ability to use class names as group descriptions

### DIFF
--- a/lua/neotest-dart/init.lua
+++ b/lua/neotest-dart/init.lua
@@ -42,7 +42,7 @@ function adapter.discover_positions(path)
   ;; group blocks
   (expression_statement 
     (identifier) @group (#eq? @group "group")
-    (selector (argument_part (arguments (argument (string_literal) @namespace.name )))))
+    (selector (argument_part (arguments . (argument (_) @namespace.name )))))
     @namespace.definition
 
   ;; tests blocks


### PR DESCRIPTION
In one of the projects I work on we have class names provided as argument for group descriptions (`Object?`)  like this:
It helps avoiding inconsistency when we rename the subject class. 

```dart
 group(LoginUseCase, () {
    test('should pass', () {
      expect(true, true);
    });
  });
```
This PR updates the TS query to match the first argument even if it's not a string.

Screenshot:

<img width="1106" alt="image" src="https://github.com/sidlatau/neotest-dart/assets/7038472/8390f2a3-6607-4f61-a4e1-eb5defed5011">

