### PR TITLE
Add working configuration for lazy.nvim users in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,41 @@ use({
 })
 ```
 
+Using lazy.nvim:
+
+```lua
+-- in neotest.lua
+return {
+  "nvim-neotest/neotest",
+  dependencies = {
+    "nvim-neotest/nvim-nio",
+    "nvim-lua/plenary.nvim",
+    "antoinemadec/FixCursorHold.nvim",
+    "nvim-treesitter/nvim-treesitter",
+    "sidlatau/neotest-dart"
+  },
+  config = function()
+    require('neotest').setup({
+      adapters = {
+        require('neotest-dart') {
+          command = 'flutter',
+          use_lsp = true
+        }
+      }
+    })
+  end
+}
+
+-- in neotest-dart.lua
+return {
+  "sidlatau/neotest-dart",
+  dependencies = {
+    "nvim-neotest/neotest",
+  },
+  lazy = false
+}
+```
+
 ## Usage
 
 For usage of `Neotest` plugin please refer to [Neotest usage section](https://github.com/nvim-neotest/neotest#usage)


### PR DESCRIPTION
I noticed a few issues similar to mine when getting this neotest adapter working where people would get "No tests found" for widget tests. Like me they were using lazy.nvim to manage plugins. I figured out a configuration which gets around these issues for me, so I added it to the README in hopes it will help others.