### PR TITLE
[ADD] config: additional_args

### DIFF
--- a/lua/neotest-dart/init.lua
+++ b/lua/neotest-dart/init.lua
@@ -13,6 +13,7 @@ adapter.root = lib.files.match_root_pattern('pubspec.yaml')
 --- Command to use for running tests. Value is set from config
 local command = 'flutter'
 local custom_test_method_names = {}
+local additional_args = {}
 
 local outline = {}
 
@@ -181,6 +182,10 @@ function adapter.build_spec(args)
   local extra_args = args.extra_args or {}
   if type(extra_args) == 'string' then
     extra_args = { extra_args }
+  else
+    for _, arg in ipairs(additional_args) do
+      table.insert(extra_args, arg)
+    end
   end
   vim.list_extend(command_parts, extra_args)
 
@@ -229,6 +234,9 @@ setmetatable(adapter, {
     end
     if config.custom_test_method_names then
       custom_test_method_names = config.custom_test_method_names
+    end
+    if config.additional_args then
+      additional_args = config.additional_args
     end
     if config.use_lsp or true then
       vim.api.nvim_create_autocmd('LspAttach', {

--- a/lua/neotest-dart/init.lua
+++ b/lua/neotest-dart/init.lua
@@ -190,7 +190,7 @@ function adapter.build_spec(args)
   vim.list_extend(command_parts, extra_args)
 
   local strategy_config = get_strategy_config(args.strategy, position.path, test_argument)
-  local full_command = table.concat(vim.tbl_flatten(command_parts), ' ')
+  local full_command = table.concat(vim.iter(command_parts):flatten():totable(), ' ')
 
   return {
     command = full_command,

--- a/lua/neotest-dart/parser.lua
+++ b/lua/neotest-dart/parser.lua
@@ -146,7 +146,7 @@ local function prepare_neotest_output(test_result, unparsable_lines)
     local test_time = format_duration(test_result.time)
     table.insert(file_output, 'Elapsed: ' .. test_time)
   end
-  local flatten = vim.tbl_flatten(file_output)
+  local flatten = vim.iter(file_output):flatten():totable()
   vim.fn.writefile(flatten, fname, 'b')
   return fname
 end

--- a/lua/neotest-dart/utils.lua
+++ b/lua/neotest-dart/utils.lua
@@ -49,7 +49,8 @@ function M.join_path(...)
   local uname = vim.loop.os_uname()
   local is_windows = uname.version:match('Windows')
   local path_sep = is_windows and '\\' or '/'
-  local result = table.concat(vim.tbl_flatten({ ... }), path_sep):gsub(path_sep .. '+', path_sep)
+  local result =
+    table.concat(vim.iter({ ... }):flatten():totable(), path_sep):gsub(path_sep .. '+', path_sep)
   return result
 end
 


### PR DESCRIPTION
Added a new config option 'additoinal_args', which - as the name suggests - lets the add in additional arguments, that are passed to every test command. I found this useful to add '--no-pub' for example, since I don't need a flutter pub get every time I run a test.

```lua
-- inside your neotest setup call
        adapters = {
          require "neotest-dart" {
            command = "flutter",
			-- pass in a table with string values
            additional_args = { "--no-pub" },
          },
		}
```
	