### PR TITLE
[REFAC] chore: fix vim.tbl_flatten deprecation

### DIFF
--- a/lua/neotest-dart/init.lua
+++ b/lua/neotest-dart/init.lua
@@ -185,7 +185,7 @@ function adapter.build_spec(args)
   vim.list_extend(command_parts, extra_args)
 
   local strategy_config = get_strategy_config(args.strategy, position.path, test_argument)
-  local full_command = table.concat(vim.tbl_flatten(command_parts), ' ')
+  local full_command = table.concat(vim.iter(command_parts):flatten():totable(), ' ')
 
   return {
     command = full_command,

--- a/lua/neotest-dart/parser.lua
+++ b/lua/neotest-dart/parser.lua
@@ -146,7 +146,7 @@ local function prepare_neotest_output(test_result, unparsable_lines)
     local test_time = format_duration(test_result.time)
     table.insert(file_output, 'Elapsed: ' .. test_time)
   end
-  local flatten = vim.tbl_flatten(file_output)
+  local flatten = vim.iter(file_output):flatten():totable()
   vim.fn.writefile(flatten, fname, 'b')
   return fname
 end

--- a/lua/neotest-dart/utils.lua
+++ b/lua/neotest-dart/utils.lua
@@ -49,7 +49,8 @@ function M.join_path(...)
   local uname = vim.loop.os_uname()
   local is_windows = uname.version:match('Windows')
   local path_sep = is_windows and '\\' or '/'
-  local result = table.concat(vim.tbl_flatten({ ... }), path_sep):gsub(path_sep .. '+', path_sep)
+  local result =
+    table.concat(vim.iter({ ... }):flatten():totable(), path_sep):gsub(path_sep .. '+', path_sep)
   return result
 end
 


### PR DESCRIPTION
I noticed, that the vim.tbl_flatten function has been deprecated. Replaced it with the suggested substitution.